### PR TITLE
refactor(build.yml): use lean-action to install elan and download cache

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -40,11 +40,12 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
-      - name: Install elan
-        run: curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-
-      - name: Get Mathlib cache
-        run: ~/.elan/bin/lake exe cache get || true
+      - name: Install and configure Lean, and get mathlib cache
+        uses: leanprover/lean-action@f3ad22e9ca29cb9475bc9bee9afd1f39bb52bf6d # v1.1.2
+        with:
+          auto-config: false
+          use-github-cache: false
+          use-mathlib-cache: true
 
       - name: Cache build artifacts
         uses: actions/cache@v4


### PR DESCRIPTION
lean-action is a centralised place to host all the basic Lean configuration: let's use this. This matches what mathlib does, since leanprover-community/mathlib4#23868 and leanprover-community/mathlib4#23914.